### PR TITLE
[ROOMS-3028] Add Gruf gRPC client/server interceptors

### DIFF
--- a/lib/appsignal/integrations/gruf/interceptors/client.rb
+++ b/lib/appsignal/integrations/gruf/interceptors/client.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Integrations
+    module Gruf
+      module Interceptors
+        class Client < ::Gruf::Interceptors::ClientInterceptor
+          def call(request_context:)
+            yield
+          rescue Exception => e
+            Appsignal.send_error(e) do |transaction|
+              transaction.set_tags(trace_data) if opentelemetry?
+              transaction.set_tags(method: request_context.method)
+            end
+
+            raise e
+          end
+
+          private
+
+          def opentelemetry?
+            defined?(OpenTelemetry)
+          end
+
+          def trace_data
+            ctx = OpenTelemetry::Trace.current_span.context
+            trace_id = ctx.trace_id.unpack1("H*")
+            span_id = ctx.span_id.unpack1("H*")
+
+            { trace_id: trace_id, span_id: span_id }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/appsignal/integrations/gruf/interceptors/server.rb
+++ b/lib/appsignal/integrations/gruf/interceptors/server.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Appsignal
+  module Integrations
+    module Gruf
+      module Interceptors
+        class Server < ::Gruf::Interceptors::ServerInterceptor
+          def call
+            yield
+          rescue Exception => e
+            Appsignal.send_error(e) do |transaction|
+              transaction.set_tags(trace_data) if opentelemetry?
+              transaction.set_tags(method: method)
+              transaction.params = request.message.to_h
+            end
+
+            raise e
+          end
+
+          private
+
+          def opentelemetry?
+            defined?(OpenTelemetry)
+          end
+
+          def trace_data
+            ctx = OpenTelemetry::Trace.current_span.context
+            trace_id = ctx.trace_id.unpack1("H*")
+            span_id = ctx.span_id.unpack1("H*")
+
+            { trace_id: trace_id, span_id: span_id }
+          end
+
+          def method
+            svc = request.service.service_name
+            endpoint = request.instance_variable_get(:@rpc_desc).name
+            "/#{svc}/#{endpoint}"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary
This adds Gruf gRPC client/server interceptors support to our fork of the appsignal gem. It also marries the current trace/span ids from OpenTelemetry with the reported exception by sending those as tags.

### Additional Links
- [ROOMS-3028]

[ROOMS-3028]: https://apptegy.atlassian.net/browse/ROOMS-3028